### PR TITLE
Prevent race condition in sampling logger

### DIFF
--- a/v2/log/sampling.go
+++ b/v2/log/sampling.go
@@ -30,6 +30,7 @@ func newSampleSyncer(tick time.Duration, first, thereafter int) zapcore.WriteSyn
 
 func (s *sampleSyncer) Write(b []byte) (int, error) {
 	s.Lock()
+	defer s.Unlock()
 	now := time.Now()
 	if now.Sub(s.lastTick) > s.tick {
 		s.count = 0
@@ -38,10 +39,8 @@ func (s *sampleSyncer) Write(b []byte) (int, error) {
 	s.lastTick = now
 
 	if s.count > s.first && s.count%s.thereafter != 0 {
-		s.Unlock()
 		return ioutil.Discard.Write(b)
 	}
-	s.Unlock()
 
 	return s.WriteSyncer.Write(b)
 }

--- a/v2/log/sampling.go
+++ b/v2/log/sampling.go
@@ -38,6 +38,7 @@ func (s *sampleSyncer) Write(b []byte) (int, error) {
 	s.lastTick = now
 
 	if s.count > s.first && s.count%s.thereafter != 0 {
+		s.Unlock()
 		return ioutil.Discard.Write(b)
 	}
 	s.Unlock()

--- a/v2/log/sampling.go
+++ b/v2/log/sampling.go
@@ -31,6 +31,7 @@ func newSampleSyncer(tick time.Duration, first, thereafter int) zapcore.WriteSyn
 func (s *sampleSyncer) Write(b []byte) (int, error) {
 	s.Lock()
 	defer s.Unlock()
+
 	now := time.Now()
 	if now.Sub(s.lastTick) > s.tick {
 		s.count = 0


### PR DESCRIPTION
Add a lock to the write method of the sampling logger to prevent race conditions.