### PR TITLE
Add a function to increase caller skips

### DIFF
--- a/v2/log/log.go
+++ b/v2/log/log.go
@@ -39,6 +39,7 @@ type Logger interface {
 	Fatal(args ...interface{})
 	Panic(args ...interface{})
 
+	AddCallerSkip(skip int)
 	CheckWrite(lvl Level, msg string, fields ...Field)
 	Sync() error
 }

--- a/v2/log/log.go
+++ b/v2/log/log.go
@@ -22,6 +22,7 @@ type Logger interface {
 	WithError(err error) Logger
 	WithTracing(ctx context.Context) Logger
 	WithUserID(ctx context.Context) Logger
+	WithCallerSkip(skip int) Logger
 
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
@@ -39,7 +40,6 @@ type Logger interface {
 	Fatal(args ...interface{})
 	Panic(args ...interface{})
 
-	AddCallerSkip(skip int)
 	CheckWrite(lvl Level, msg string, fields ...Field)
 	Sync() error
 }

--- a/v2/log/logger.go
+++ b/v2/log/logger.go
@@ -14,6 +14,10 @@ type logger struct {
 	logger *zap.SugaredLogger
 }
 
+func (l logger) AddCallerSkip(skip int) {
+	l.logger = l.logger.Desugar().WithOptions(zap.AddCallerSkip(skip)).Sugar()
+}
+
 func (l logger) WithField(key string, value interface{}) Logger {
 	return logger{l.logger.With(zap.Any(key, value))}
 }

--- a/v2/log/logger.go
+++ b/v2/log/logger.go
@@ -14,10 +14,6 @@ type logger struct {
 	logger *zap.SugaredLogger
 }
 
-func (l logger) AddCallerSkip(skip int) {
-	l.logger = l.logger.Desugar().WithOptions(zap.AddCallerSkip(skip)).Sugar()
-}
-
 func (l logger) WithField(key string, value interface{}) Logger {
 	return logger{l.logger.With(zap.Any(key, value))}
 }
@@ -58,6 +54,10 @@ func (l logger) WithUserID(ctx context.Context) Logger {
 	}
 
 	return l
+}
+
+func (l logger) WithCallerSkip(skip int) Logger {
+	return logger{l.logger.Desugar().WithOptions(zap.AddCallerSkip(skip)).Sugar()}
 }
 
 func (l logger) Debugf(format string, args ...interface{}) {


### PR DESCRIPTION
The function increases, or decreases, the number of callers the log skips when adding source information.

Useful when a user of this package wraps it in an internal package.