### PR TITLE
Don't create a root span

### DIFF
--- a/v2/http-middleware/security.go
+++ b/v2/http-middleware/security.go
@@ -81,7 +81,6 @@ func AuthenticateMiddlewareV3() mux.MiddlewareFunc {
 					return
 				}
 			}
-			span.End()
 
 			span.End()
 			next.ServeHTTP(w, req)
@@ -234,7 +233,6 @@ func AuthorizeMiddleware(authorizer Authorizer) mux.MiddlewareFunc {
 				http_server.WriteJSONResponse(ctx, w, req, http.StatusUnauthorized, http_model.ErrResponseUnauthorized)
 				return
 			}
-			span.End()
 
 			span.End()
 			next.ServeHTTP(w, req)


### PR DESCRIPTION
If the context in the request does not have a span a span should not be created in order to not leave new root spans from middleware functions.