### PR TITLE
Add vars & query parameters to trace span

### DIFF
--- a/v2/http-middleware/opencensus.go
+++ b/v2/http-middleware/opencensus.go
@@ -1,6 +1,7 @@
 package httpmiddleware
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -14,6 +15,24 @@ func OpenCensusMiddleware(next http.Handler) http.Handler {
 		if span == nil {
 			next.ServeHTTP(w, req)
 			return
+		}
+
+		for key, value := range mux.Vars(req) {
+			span.AddAttributes(trace.StringAttribute(fmt.Sprintf("vars.%s", key), value))
+		}
+
+		for key, values := range req.URL.Query() {
+			key = fmt.Sprintf("query.%s", key)
+			switch len(values) {
+			case 0:
+				continue
+			case 1: // nolint: gomnd
+				span.AddAttributes(trace.StringAttribute(key, values[0]))
+			default:
+				for i := range values {
+					span.AddAttributes(trace.StringAttribute(fmt.Sprintf("%s.%d", key, i), values[i]))
+				}
+			}
 		}
 
 		route := mux.CurrentRoute(req)


### PR DESCRIPTION
Adds variables and query parameters from the request as attributes to the span in the opentracing middleware.