### PR TITLE
Quote string when resource is query

### DIFF
--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -3,12 +3,14 @@ package ddpgx
 import (
 	"context"
 	"fmt"
-	"strings"
+	"regexp"
 	"time"
 
 	dd_ext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	dd_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
+
+var newlineIndent = regexp.MustCompile(`\\n\s+`)
 
 type internalTracer struct {
 	serviceName string
@@ -45,7 +47,7 @@ func (t internalTracer) TryTrace(ctx context.Context, startTime time.Time, resou
 	}
 
 	if query, ok := metadata[dd_ext.SQLQuery]; ok {
-		span.SetTag(dd_ext.ResourceName, strings.Replace(fmt.Sprintf("%s", query), "\n", "", -1))
+		span.SetTag(dd_ext.ResourceName, newlineIndent.ReplaceAllString(fmt.Sprintf("%v", query), " "))
 	} else {
 		span.SetTag(dd_ext.ResourceName, resource)
 	}

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	dd_ext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	dd_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
-var newlineIndent = regexp.MustCompile(`\\n\s+`)
+var newlineIndent = regexp.MustCompile(`\n\s+`)
 
 type internalTracer struct {
 	serviceName string
@@ -47,7 +48,11 @@ func (t internalTracer) TryTrace(ctx context.Context, startTime time.Time, resou
 	}
 
 	if query, ok := metadata[dd_ext.SQLQuery]; ok {
-		span.SetTag(dd_ext.ResourceName, newlineIndent.ReplaceAllString(fmt.Sprintf("%v", query), " "))
+		q := fmt.Sprintf("%v", query)
+		q = strings.TrimSpace(q)
+		q = newlineIndent.ReplaceAllString(q, " ")
+
+		span.SetTag(dd_ext.ResourceName, q)
 	} else {
 		span.SetTag(dd_ext.ResourceName, resource)
 	}

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -3,6 +3,7 @@ package ddpgx
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	dd_ext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
@@ -44,7 +45,7 @@ func (t internalTracer) TryTrace(ctx context.Context, startTime time.Time, resou
 	}
 
 	if query, ok := metadata[dd_ext.SQLQuery]; ok {
-		span.SetTag(dd_ext.ResourceName, query)
+		span.SetTag(dd_ext.ResourceName, strings.Replace(fmt.Sprintf("%s", query), "\n", "", -1))
 	} else {
 		span.SetTag(dd_ext.ResourceName, resource)
 	}

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -44,15 +44,19 @@ func (t internalTracer) TryTrace(ctx context.Context, startTime time.Time, resou
 	span.SetTag("sql.method", resource)
 
 	for key, value := range metadata {
+		if key == dd_ext.SQLQuery {
+			q := fmt.Sprintf("%v", value)
+			q = strings.TrimSpace(q)
+			q = newlineIndent.ReplaceAllString(q, " ")
+
+			metadata[key] = q
+		}
+
 		span.SetTag(key, value)
 	}
 
 	if query, ok := metadata[dd_ext.SQLQuery]; ok {
-		q := fmt.Sprintf("%v", query)
-		q = strings.TrimSpace(q)
-		q = newlineIndent.ReplaceAllString(q, " ")
-
-		span.SetTag(dd_ext.ResourceName, q)
+		span.SetTag(dd_ext.ResourceName, query)
 	} else {
 		span.SetTag(dd_ext.ResourceName, resource)
 	}


### PR DESCRIPTION
Prints the query as a quoted string when adding it as a resource to the trace.

The Datadog tracer prints traces to stdout when the environment variable DD_FLUSH_TO_LOG is set to true. If the resource field contains newline characters this ends up printing the trace over multiple lines, which then causes the Datadog log forwarder to not be able to send the traces to Datadog.