### PR TITLE
Add Nop() for getting a silent logger

### DIFF
--- a/v2/log/log.go
+++ b/v2/log/log.go
@@ -46,7 +46,6 @@ type Logger interface {
 var (
 	baseLogger logger
 	fields     []zap.Field
-	nopLogger  logger
 )
 
 const skipsToOriginialCaller = 1
@@ -54,7 +53,6 @@ const skipsToOriginialCaller = 1
 func init() {
 	origLogger := newLogger(zapcore.Lock(os.Stdout))
 	baseLogger = logger{origLogger.Sugar()}
-	nopLogger = logger{zap.NewNop().Sugar()}
 }
 
 func newLogger(syncer zapcore.WriteSyncer) *zap.Logger {
@@ -124,7 +122,7 @@ func Base() Logger {
 }
 
 func Nop() Logger {
-	return nopLogger
+	return logger{zap.NewNop().Sugar()}
 }
 
 func WithField(key string, value interface{}) Logger {

--- a/v2/log/log.go
+++ b/v2/log/log.go
@@ -46,6 +46,7 @@ type Logger interface {
 var (
 	baseLogger logger
 	fields     []zap.Field
+	nopLogger  logger
 )
 
 const skipsToOriginialCaller = 1
@@ -53,6 +54,7 @@ const skipsToOriginialCaller = 1
 func init() {
 	origLogger := newLogger(zapcore.Lock(os.Stdout))
 	baseLogger = logger{origLogger.Sugar()}
+	nopLogger = logger{zap.NewNop().Sugar()}
 }
 
 func newLogger(syncer zapcore.WriteSyncer) *zap.Logger {
@@ -119,6 +121,10 @@ func getEncoder() zapcore.Encoder {
 
 func Base() Logger {
 	return baseLogger
+}
+
+func Nop() Logger {
+	return nopLogger
 }
 
 func WithField(key string, value interface{}) Logger {


### PR DESCRIPTION
  This is added as an alternative to use in unit tests.

  When testing a module that produces log output, the output from the test may
  be mixed by log output if the normal logger is used.