### PR TITLE
Support full ARN in secretsmanagerauth

### DIFF
--- a/v2/auth/secretsmanagerauth/sign_in.go
+++ b/v2/auth/secretsmanagerauth/sign_in.go
@@ -100,9 +100,9 @@ func SignIn(ctx context.Context) (err error) {
 func signIn(ctx context.Context) (tokens auth.Tokens, err error) {
 	svc := secretsmanager.New(config.AWSSession)
 
-	var secretKey string
+	secretKey := config.SecretKeyARN
 
-	if secretKey = config.SecretKeyARN; secretKey == "" {
+	if secretKey == "" {
 		secretKey = "arn:aws:secretsmanager:" + config.AWSSecretsManagerRegion + ":" + config.AWSSecretsManagerAccount + ":secret:" + config.SecretKey
 	}
 

--- a/v2/auth/secretsmanagerauth/sign_in.go
+++ b/v2/auth/secretsmanagerauth/sign_in.go
@@ -28,6 +28,7 @@ type Config struct {
 	WithOpenCensusTracing    bool   // default and used when you trace your application with Open Census
 	ServiceName              string // needed when using lambda and Datadog for tracing
 	AWSSession               *session.Session
+	SecretKeyARN             string
 	AWSSecretsManagerAccount string
 	AWSSecretsManagerRegion  string
 	SecretKey                string
@@ -99,7 +100,11 @@ func SignIn(ctx context.Context) (err error) {
 func signIn(ctx context.Context) (tokens auth.Tokens, err error) {
 	svc := secretsmanager.New(config.AWSSession)
 
-	secretKey := "arn:aws:secretsmanager:" + config.AWSSecretsManagerRegion + ":" + config.AWSSecretsManagerAccount + ":secret:" + config.SecretKey
+	var secretKey string
+
+	if secretKey = config.SecretKeyARN; secretKey == "" {
+		secretKey = "arn:aws:secretsmanager:" + config.AWSSecretsManagerRegion + ":" + config.AWSSecretsManagerAccount + ":secret:" + config.SecretKey
+	}
 
 	output, err := svc.GetSecretValueWithContext(ctx, &secretsmanager.GetSecretValueInput{SecretId: &secretKey})
 	if err != nil {


### PR DESCRIPTION
If your service key name happens to end in a hyphen and six characters, AWS will assume this to be a full ARN when fetching the secret, and the policy on the secret in the users account will deny the request.

By fetching the full ARN and using this in the config this problem can be circumvented.

This should be implemented in way where if an ARN is configured the value is used, otherwise the legacy behavior is assumed.