### PR TITLE
Use existing TTL functions in cache

### DIFF
--- a/v2/cache/cache.go
+++ b/v2/cache/cache.go
@@ -43,7 +43,6 @@ func New(ttl time.Duration, cacheSizeMaxMB int64) (*Cache, error) {
 		BufferItems: 64,       // nolint: gomnd number of keys per Get buffer.
 		Metrics:     true,
 	})
-
 	if err != nil {
 		err = errors.Wrap(err, "Error creating cache")
 		log.WithError(err).Error("Error creating cache")

--- a/v2/cache/cache.go
+++ b/v2/cache/cache.go
@@ -9,13 +9,19 @@ import (
 	"github.com/SKF/go-utility/v2/log"
 )
 
+const (
+	defaultNumCounters = 1000000 // default number of keys to track frequency of (1M).
+	defaultBufferItems = 64      // default number of keys per Get buffer.
+
+	megaByte = 1 << 10
+)
+
 type Cache struct {
 	cache          *ristretto.Cache
 	log            log.Logger
 	gets           uint64
 	sets           uint64
 	perFuncMetrics map[string]*perFuncMetric
-	expired        uint64
 	ttl            time.Duration
 }
 
@@ -24,23 +30,18 @@ type perFuncMetric struct {
 	hits uint64
 }
 
-type item struct {
-	expiration time.Time
-	data       interface{}
-}
-
 func New(ttl time.Duration, cacheSizeMaxMB int64) (*Cache, error) {
 	if ttl <= 0 {
 		log.Infof("Caching disabled, TTL: %d", ttl)
 	}
 
-	maxCache := cacheSizeMaxMB * 1024 * 1024 // nolint:gomnd byte to mb
+	maxCache := cacheSizeMaxMB * megaByte
 	log.Infof("Cache size in bytes: %d", maxCache)
 
 	memcache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1000000,  // nolint: gomnd number of keys to track frequency of (1M).
+		NumCounters: defaultNumCounters,
 		MaxCost:     maxCache, // maximum cost of cache.
-		BufferItems: 64,       // nolint: gomnd number of keys per Get buffer.
+		BufferItems: defaultBufferItems,
 		Metrics:     true,
 	})
 	if err != nil {

--- a/v2/cache/get.go
+++ b/v2/cache/get.go
@@ -1,9 +1,5 @@
 package cache
 
-import (
-	"time"
-)
-
 func (c *Cache) Exist(key ObjectKey) bool {
 	_, ok := c.Get(key)
 	return ok
@@ -18,21 +14,14 @@ func (c *Cache) Get(key ObjectKey) (obj interface{}, ok bool) {
 		c.perFuncMetrics[key.FuncName()] = &perFuncMetric{}
 	}
 
+	data, found := c.cache.Get(string(key))
+
 	c.gets++
 	c.perFuncMetrics[key.FuncName()].gets++
 
-	data, found := c.cache.Get(string(key))
-	if found && data != nil {
-		if dataItem, ok := data.(item); ok {
-			if time.Now().Before(dataItem.expiration) {
-				c.perFuncMetrics[key.FuncName()].hits++
-				return dataItem.data, true
-			}
-
-			c.expired++
-			c.cache.Del(string(key))
-		}
+	if found {
+		c.perFuncMetrics[key.FuncName()].hits++
 	}
 
-	return nil, false
+	return data, found
 }

--- a/v2/cache/set.go
+++ b/v2/cache/set.go
@@ -1,27 +1,11 @@
 package cache
 
-import (
-	"time"
-
-	"github.com/SKF/go-utility/v2/log"
-)
-
 func (c *Cache) Set(key ObjectKey, value interface{}) bool {
-	if c.ttl > 0 {
-		c.sets++
-
-		data := item{
-			expiration: time.Now().Add(c.ttl),
-			data:       value,
-		}
-
-		ok := c.cache.Set(string(key), data, 1)
-		if !ok {
-			log.Warnf("Cache insert dropped: %s", key)
-		}
-
-		return ok
+	if c.ttl <= 0 {
+		return false
 	}
 
-	return false
+	c.sets++
+
+	return c.cache.SetWithTTL(string(key), value, 1, c.ttl)
 }


### PR DESCRIPTION
The ristretto cache has functions for using TTL on items written to the cache. Update the cache to use those functions instead of implementing the same functionality manually.

The minor difference is that our implementation had 0 TTL mean caching is disabled, while ristretto has 0 TTL mean that items never expire.

The existing behaviour is kept, which is why the Set/Get functions checks for ttl being 0 instead of calling the Set/Get functions directly.