### PR TITLE
Remove logging from tracing functions

### DIFF
--- a/v2/trace/aws/inject.go
+++ b/v2/trace/aws/inject.go
@@ -11,7 +11,6 @@ import (
 	oc_trace "go.opencensus.io/trace"
 	dd_tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
-	"github.com/SKF/go-utility/v2/log"
 	"github.com/SKF/go-utility/v2/trace"
 )
 
@@ -88,10 +87,6 @@ func getTraceAttributesFromContext(ctx context.Context) map[string]string {
 		attributes[trace.DatadogTraceIDHeader] = traceID
 		attributes[trace.DatadogParentIDHeader] = spanID
 	}
-
-	log.WithTracing(ctx).
-		WithField("headers", attributes).
-		Debug("Injecting trace headers")
 
 	return attributes
 }


### PR DESCRIPTION
There are debug logs being printed by the functions that inject/extract tracing for AWS. These add a lot of unnecessary logs when debug logging is enabled for a Lambda function.

The code itself has been proven to work, so having these debug logs add little value.