### PR TITLE
Migrate JWT package

### DIFF
--- a/v2/auth/jwt.go
+++ b/v2/auth/jwt.go
@@ -16,7 +16,7 @@ func IsTokenValid(token string, tokenExpireDurationDiff time.Duration) bool {
 		SkipClaimsValidation: true,
 	}
 
-	var claims jwt.StandardClaims
+	var claims jwt.RegisteredClaims
 
 	_, _, err := parser.ParseUnverified(token, &claims)
 	if err != nil {
@@ -25,7 +25,7 @@ func IsTokenValid(token string, tokenExpireDurationDiff time.Duration) bool {
 
 	// Verify if token still valid within the current time diff
 	// no need to sign in once again
-	ts := time.Now().Add(tokenExpireDurationDiff).Unix()
+	ts := time.Now().Add(tokenExpireDurationDiff)
 
 	return claims.VerifyExpiresAt(ts, false) &&
 		claims.VerifyIssuedAt(ts, false) &&

--- a/v2/auth/jwt.go
+++ b/v2/auth/jwt.go
@@ -3,7 +3,7 @@ package auth
 import (
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // IsTokenValid checks if the token is still valid
@@ -17,8 +17,8 @@ func IsTokenValid(token string, tokenExpireDurationDiff time.Duration) bool {
 	}
 
 	var claims jwt.StandardClaims
-	_, _, err := parser.ParseUnverified(token, &claims)
 
+	_, _, err := parser.ParseUnverified(token, &claims)
 	if err != nil {
 		return false
 	}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-lambda-go v1.20.0
 	github.com/aws/aws-sdk-go v1.35.30
 	github.com/dgraph-io/ristretto v0.0.3
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gomodule/redigo v1.8.2
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/mux v1.8.0

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -64,7 +64,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
 github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -88,6 +87,8 @@ github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPh
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/v2/http-middleware/security.go
+++ b/v2/http-middleware/security.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"net/http"
 
+	rest "github.com/SKF/go-rest-utility/client"
+	"github.com/SKF/proto/v2/common"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	rest "github.com/SKF/go-rest-utility/client"
 	"github.com/SKF/go-utility/v2/accesstokensubcontext"
 	"github.com/SKF/go-utility/v2/auth"
 	"github.com/SKF/go-utility/v2/http-middleware/util"
@@ -19,7 +20,6 @@ import (
 	"github.com/SKF/go-utility/v2/jwt"
 	"github.com/SKF/go-utility/v2/log"
 	"github.com/SKF/go-utility/v2/useridcontext"
-	"github.com/SKF/proto/v2/common"
 )
 
 const (

--- a/v2/http-middleware/security.go
+++ b/v2/http-middleware/security.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -17,6 +16,7 @@ import (
 	http_model "github.com/SKF/go-utility/v2/http-model"
 	http_server "github.com/SKF/go-utility/v2/http-server"
 	"github.com/SKF/go-utility/v2/jwk"
+	"github.com/SKF/go-utility/v2/jwt"
 	"github.com/SKF/go-utility/v2/log"
 	"github.com/SKF/go-utility/v2/useridcontext"
 	"github.com/SKF/proto/v2/common"

--- a/v2/http-middleware/security.go
+++ b/v2/http-middleware/security.go
@@ -4,22 +4,22 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	rest "github.com/SKF/go-rest-utility/client"
 	"github.com/SKF/go-utility/v2/accesstokensubcontext"
 	"github.com/SKF/go-utility/v2/auth"
 	"github.com/SKF/go-utility/v2/http-middleware/util"
 	http_model "github.com/SKF/go-utility/v2/http-model"
 	http_server "github.com/SKF/go-utility/v2/http-server"
 	"github.com/SKF/go-utility/v2/jwk"
-	"github.com/SKF/go-utility/v2/jwt"
 	"github.com/SKF/go-utility/v2/log"
 	"github.com/SKF/go-utility/v2/useridcontext"
-
-	rest "github.com/SKF/go-rest-utility/client"
 	"github.com/SKF/proto/v2/common"
-	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (

--- a/v2/jwt/jwt.go
+++ b/v2/jwt/jwt.go
@@ -1,10 +1,10 @@
 package jwt
 
 import (
-	"github.com/SKF/go-utility/v2/jwk"
-
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
+
+	"github.com/SKF/go-utility/v2/jwk"
 )
 
 type Token jwt.Token
@@ -36,8 +36,10 @@ type Claims struct {
 	EnlightClaims
 }
 
-const TokenUseAccess = "access"
-const TokenUseID = "id"
+const (
+	TokenUseAccess = "access"
+	TokenUseID     = "id"
+)
 
 func (c Claims) Valid() (err error) {
 	if err = c.StandardClaims.Valid(); err != nil {
@@ -85,7 +87,6 @@ func Parse(jwtToken string) (_ Token, err error) {
 			return key.GetPublicKey()
 		},
 	)
-
 	if err != nil {
 		err = errors.Wrap(err, "parse with claims failed")
 		return

--- a/v2/jwt/jwt.go
+++ b/v2/jwt/jwt.go
@@ -31,7 +31,7 @@ type EnlightClaims struct {
 }
 
 type Claims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	CognitoClaims
 	EnlightClaims
 }
@@ -42,7 +42,7 @@ const (
 )
 
 func (c Claims) Valid() (err error) {
-	if err = c.StandardClaims.Valid(); err != nil {
+	if err = c.RegisteredClaims.Valid(); err != nil {
 		return
 	}
 


### PR DESCRIPTION
The github.com/dgrijalva/jwt-go is deprecated and replaced by the new package. The deprecated library has a vulnerability that has not be released as a stable version.

The issue on the deprecated package: https://github.com/dgrijalva/jwt-go/issues/422

The correction in the new package version is here: https://github.com/golang-jwt/jwt/issues/6