### PR TITLE
changes for impersonation

### DIFF
--- a/v2/jwt/jwt.go
+++ b/v2/jwt/jwt.go
@@ -19,8 +19,9 @@ func (t Token) GetClaims() Claims {
 }
 
 type CognitoClaims struct {
-	Username string `json:"username"`
-	TokenUse string `json:"token_use"`
+	Username      string   `json:"username"`
+	TokenUse      string   `json:"token_use"`
+	CognitoGroups []string `json:"cognito:groups"`
 }
 
 type EnlightClaims struct {


### PR DESCRIPTION
Memory map key has been changed to username to provide seamless impersonation.

There is no way to change tokens' claims.Subject in Cognito. So, we applied a workaround to get the user for impersonation from the access token. (ID token will be generated for the impersonated user in such cases.)

In order to be successful, cache key should be set as a username. If token is created for impersonation, the cache key will be the impersonated user's username. Required changes for getUserIDByToken for impersonation has been done on users repo. If a token ,which includes impersonation attribute, is sent to /users/me endpoint, it will return impersonated user's information instead of admin user.

Since username attribute in Cognito is unique as well, no harm to change the cache key to username.
Ref: https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-settings-attributes.html