### PR TITLE
#304131 - avoid logging very large arrays, causing bloated logs and 3…

### DIFF
--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -67,8 +67,8 @@ func argsToAttributes(args ...interface{}) map[string]interface{} {
 
 		switch x := args[i].(type) {
 		case []float64:
-			if len(x) > maxArraySizeToLog {
-				output[key] = len(x) // avoiding excessive logging sizes and costs #304131
+			if len(x) > maxArraySizeToLog { // avoiding excessive logging sizes and costs #304131
+				output[key] = fmt.Sprintf("<a float array of length %d>", len(x))
 			} else {
 				output[key] = args[i]
 			}

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -12,7 +12,8 @@ import (
 )
 
 var (
-	patternNewlines = regexp.MustCompile(`\s*\r?\n\s*`)
+	maxArraySizeToLog = 100
+	patternNewlines   = regexp.MustCompile(`\s*\r?\n\s*`)
 )
 
 type internalTracer struct {
@@ -63,7 +64,16 @@ func argsToAttributes(args ...interface{}) map[string]interface{} {
 
 	for i := range args {
 		key := fmt.Sprintf("sql.args.%d", i)
-		output[key] = args[i]
+		switch x := args[i].(type) {
+		case []float64:
+			if len(x) > maxArraySizeToLog {
+				output[key] = len(x) // avoiding excessive logging sizes and costs #304131
+			} else {
+				output[key] = args[i]
+			}
+		default:
+			output[key] = args[i]
+		}
 	}
 
 	return output

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -64,6 +64,7 @@ func argsToAttributes(args ...interface{}) map[string]interface{} {
 
 	for i := range args {
 		key := fmt.Sprintf("sql.args.%d", i)
+		
 		switch x := args[i].(type) {
 		case []float64:
 			if len(x) > maxArraySizeToLog {

--- a/v2/trace/ddpgx/trace.go
+++ b/v2/trace/ddpgx/trace.go
@@ -64,7 +64,7 @@ func argsToAttributes(args ...interface{}) map[string]interface{} {
 
 	for i := range args {
 		key := fmt.Sprintf("sql.args.%d", i)
-		
+
 		switch x := args[i].(type) {
 		case []float64:
 			if len(x) > maxArraySizeToLog {


### PR DESCRIPTION
Bloated logs from timeseries and spectrum logs costs 30% of all log costs