### PR TITLE
Support logging only on only

### DIFF
--- a/v2/log/logger.go
+++ b/v2/log/logger.go
@@ -74,6 +74,16 @@ func (l logger) WithUserID(ctx context.Context) Logger {
 	return l
 }
 
+func (l logger) OnlyWithTracing(ctx context.Context) Logger {
+	if _, exists := dd_tracer.SpanFromContext(ctx); exists {
+		return l.WithTracing(ctx)
+	} else if span := oc_trace.FromContext(ctx); span != nil {
+		return l.WithTracing(ctx)
+	}
+
+	return Nop()
+}
+
 func (l logger) Debugf(format string, args ...interface{}) {
 	l.logger.Debugf(format, args...)
 }


### PR DESCRIPTION
Adds a function which can be used in instances where you only want to log when there's an active trace. The function returns a noop logger if a trace is not found in the context, which would then not print anything when logged.

This would be useful in instances where an application is configured to trace less than 100% of requests, and the application wants to avoid logging e.g. debug statements when no trace is present.