### PR TITLE
Expose OnlyWithTracing correctly

### DIFF
--- a/v2/log/log.go
+++ b/v2/log/log.go
@@ -23,6 +23,7 @@ type Logger interface {
 	WithError(err error) Logger
 	WithTracing(ctx context.Context) Logger
 	WithUserID(ctx context.Context) Logger
+	OnlyWithTracing(ctx context.Context) Logger
 
 	Debugf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
@@ -149,6 +150,10 @@ func WithClientID(ctx context.Context) Logger {
 
 func WithUserID(ctx context.Context) Logger {
 	return baseLogger.WithUserID(ctx)
+}
+
+func OnlyWithTracing(ctx context.Context) Logger {
+	return baseLogger.OnlyWithTracing(ctx)
 }
 
 // We must directly call the bundled logger here (whenever a func instead of

--- a/v2/log/log_test.go
+++ b/v2/log/log_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -28,6 +29,8 @@ func TestLog(t *testing.T) {
 	log.WithField("application", "backend").Debug("This is a debug message")
 	log.WithField("token", "1234").Warning("A warning msg")
 	log.WithError(errors.New("A test error")).Error("A test error, should have stacktrace")
+	log.WithTracing(context.TODO()).Info("Actual tracing information would be empty")
+	log.OnlyWithTracing(context.TODO()).Info("Empty context should not log anything")
 
 	assert.Panics(t, panicLog)
 }


### PR DESCRIPTION
The new function to only log on tracing was not exposed correctly through the logger interface and package functions.