### PR TITLE
Increase wait time for cache

### DIFF
--- a/v2/cache/cache_test.go
+++ b/v2/cache/cache_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	wait          = 1 * time.Millisecond
+	wait          = 3 * time.Millisecond
 	TTL           = 5 * wait
 	NoTTL         = 0
 	cacheFuncKey  = "myFunc"


### PR DESCRIPTION
The cache unit tests wait before continuing with verification to allow the events writing to the internal cache to complete. This appears to be too short as some of the tests in this package fail intermittently.