### PR TITLE
Deprecate the v1 module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: daily
-  - package-ecosystem: gomod
     directory: /v2
     schedule:
       interval: daily

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Please use github.com/SKF/go-utility/v2 instead.
 module github.com/SKF/go-utility
 
 go 1.19


### PR DESCRIPTION
Adds a deprecation message to the v1 version of this module. Also remove the config for dependabot to update the v1 module to avoid unnecessary PRs.